### PR TITLE
Fix folder creation for patreon data

### DIFF
--- a/src_back/bootstrap.ts
+++ b/src_back/bootstrap.ts
@@ -50,7 +50,7 @@ fs.mkdirSync(Config.USER_DATA_BACKUP_PATH, { recursive: true });
 fs.mkdirSync(Config.BETA_DATA_FOLDER, { recursive: true });
 fs.mkdirSync(Config.DONORS_DATA_FOLDER, { recursive: true });
 fs.mkdirSync(Config.DISCORD_DATA_FOLDER, { recursive: true });
-fs.mkdirSync(Config.DISCORD_DATA_FOLDER, { recursive: true });
+fs.mkdirSync(Config.PATREON_DATA_FOLDER, { recursive: true });
 fs.mkdirSync(Config.KO_FI_DATA_FOLDER, { recursive: true });
 fs.mkdirSync(Config.TILTIFY_DATA_FOLDER, { recursive: true });
 fs.mkdirSync(Config.LOGS_FOLDER, { recursive: true });


### PR DESCRIPTION
## Summary
- ensure patreon folder created during bootstrap

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453b5e5650832ea33f0403d1213bbb