### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ node server/boostrap.js
 <br>
 
 # Install server
-All the following MUST be done on a seperate folder from the GIT project.\
+All the following MUST be done on a separate folder from the GIT project.\
 [Compile the project](#compile-project) and push the content of the `server` folder on your server root.\
 Next to this file, create a `public` folder and push the content of your local `dist` folder inside it.\
-Also add the `credentials` folder inside a `data` older at the root of the project.\
+Also add the `credentials` folder inside a `data` folder at the root of the project.\
 Create an `env.conf` file, just write `prod` inside, and push it at the root of the project.\
 Install all the production dependencies and [run the server](#run-server).
 \


### PR DESCRIPTION
## Summary
- fix some minor typos in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: invalid option)*

------
https://chatgpt.com/codex/tasks/task_e_68453b41d3c0832ea7fbe140627ceb67